### PR TITLE
Fix input warnings from job output

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -10,6 +10,12 @@ inputs:
   github-token:
     description: The `GITHUB_TOKEN` secret.
     required: true
+  issue-close-message:
+    description: Use default message or input field.
+    required: false
+  closed-issues-label:
+    description: Use default label or input field.
+    required: false
 
 runs:
   using: "node12"


### PR DESCRIPTION
GitHub output two warning about possible unintentional inputs:
```
.github#L1
Unexpected input 'closed-issues-label', valid inputs are ['github-token']
```

With this pull request fix, warnings are no longer output.